### PR TITLE
fix: center image crops for thumbnails

### DIFF
--- a/public/style/global.css
+++ b/public/style/global.css
@@ -125,8 +125,10 @@ a {
 }
 
 .product img {
-  max-width: 300px;
+  width: 100%;
   border-radius: 10px;
+  object-fit: cover;
+  height: 100%;
 }
 
 .product-page {


### PR DESCRIPTION
before:

<img width="484" alt="Screen Shot 2021-06-27 at 12 03 12 PM" src="https://user-images.githubusercontent.com/163561/123556417-fa77d180-d73f-11eb-86f9-b8cee3cb735d.png">

after:

<img width="481" alt="Screen Shot 2021-06-27 at 12 05 21 PM" src="https://user-images.githubusercontent.com/163561/123556423-fe0b5880-d73f-11eb-984e-06c7e1a16dfe.png">

fixes #1